### PR TITLE
[omnibus] pyc pre-compile and cleanup

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -13,11 +13,24 @@ description "steps required to finalize the build"
 default_version "1.0.0"
 skip_transitive_dependency_licensing true
 
+python_version = ENV['PYTHON_VERSION']
+if python_version.nil? || python_version.empty? || python_version == "3"
+  dependency "python3"
+elsif python_version == "2"
+  dependency "python"
+  dependency 'pip'
+end
+
 build do
-  # TODO too many things done here, should be split
+  python_path = "#{install_dir}/embedded/bin/python"
+
   block do
     etc_dir = "/etc/datadog-agent"
     var_dir = "/var/log/datadog"
+
+    # compile pyc files
+    command "#{python_path} -m compileall #{install_dir}"
+    command "find . -type f -name '*.pyc' >> #{install_dir}/.pyc_compiled_files", :cwd => install_dir
 
     # Conf files
     if aix?

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -23,14 +23,16 @@ end
 
 build do
   python_path = "#{install_dir}/embedded/bin/python"
+  pyc_compiled_files = "#{install_dir}/embedded/.pyc_compiled_files.txt"
+  pyc_mask_re = "lib\/python.*\/test/.*|lib\/python.*\/lib2to3\/tests/.*"
 
   block do
     etc_dir = "/etc/datadog-agent"
     var_dir = "/var/log/datadog"
 
     # compile pyc files
-    command "#{python_path} -m compileall #{install_dir}"
-    command "find . -type f -name '*.pyc' >> #{install_dir}/.pyc_compiled_files", :cwd => install_dir
+    command "#{python_path} -m compileall #{install_dir} -x '#{pyc_mask_re}'"
+    command "find . -type f -name '*.pyc' >> #{pyc_compiled_files}", :cwd => install_dir
 
     # Conf files
     if aix?

--- a/omnibus/config/software/pynacl.rb
+++ b/omnibus/config/software/pynacl.rb
@@ -23,7 +23,7 @@ build do
   ship_license "https://raw.githubusercontent.com/pyca/pynacl/master/LICENSE"
 
   if aix?
-    env = aix_env 
+    env = aix_env
   else
     env = with_standard_compiler_flags(with_embedded_path)
   end

--- a/omnibus/package-scripts/agent/aix/preinst
+++ b/omnibus/package-scripts/agent/aix/preinst
@@ -9,6 +9,7 @@
 INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 SERVICE_NAME=datadog-agent
+PYC_COMPILED_FILES=$INSTALL_DIR/embedded/.pyc_compiled_files.txt
 
 set -e
 
@@ -24,9 +25,9 @@ tentative_stop_datadog_services()
 tentative_stop_datadog_services
 
 # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
-if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
+if [ -f "$PYC_COMPILED_FILES" ]; then
     # (commented lines are filtered out)
-    cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+    cat $PYC_COMPILED_FILES | grep -v '^#' | xargs rm -f
 fi
 
 exit 0

--- a/omnibus/package-scripts/agent/aix/prerm
+++ b/omnibus/package-scripts/agent/aix/prerm
@@ -8,6 +8,7 @@
 
 INSTALL_DIR=/opt/datadog-agent
 SERVICE_NAME=datadog-agent
+PYC_COMPILED_FILES=$INSTALL_DIR/embedded/.pyc_compiled_files.txt
 
 
 stop_datadog_services()
@@ -23,15 +24,15 @@ stop_datadog_services()
 remove_py_compiled_files()
 {
     # Delete all the .pyc files in the embedded dir that are part of the agent's package
-    if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
+    if [ -f "$PYC_COMPILED_FILES" ]; then
         # (commented lines are filtered out)
-        cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+        cat $PYC_COMPILED_FILES | grep -v '^#' | xargs rm -f
     fi
 }
 
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
-# remove_py_compiled_files
+remove_py_compiled_files
 
 stop_datadog_services
 

--- a/omnibus/package-scripts/agent/aix/prerm
+++ b/omnibus/package-scripts/agent/aix/prerm
@@ -18,10 +18,7 @@ stop_datadog_services()
   stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
 }
 
-# TODO: make sure this all makes sense on AIX.
-#
-#       Enable once we pre-compile the bytecode.
-remove_py_compiled_files()
+remove_pyc_compiled_files()
 {
     # Delete all the .pyc files in the embedded dir that are part of the agent's package
     if [ -f "$PYC_COMPILED_FILES" ]; then
@@ -32,7 +29,7 @@ remove_py_compiled_files()
 
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
-remove_py_compiled_files
+remove_pyc_compiled_files
 
 stop_datadog_services
 


### PR DESCRIPTION
As per the omnibus docs (https://www.rubydoc.info/github/opscode/omnibus/Omnibus/Packager/BFF):
```
The order of the installp scripts is:

- install
  * pre-install
  * post-install
  * config

- upgrade
  * pre-remove (of previous version)
  * pre-install (previous version of software not present anymore)
  * post-install
  * config

- remove
  * unconfig
  * unpre-install
```

This might get slightly confusing at times, but please take a look at the source code if in doubt.