### PR TITLE
[hostname] don't enforce RFC1123 compliance on collected hostnames

### DIFF
--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -47,9 +47,6 @@ def _get_hostname(cmd=[], validate=False):
             return fqdn
 
 def get_hostname_std(validate=False):
-    return _get_hostname(['/bin/hostname', '-s'], validate)
-
-def get_hostname_solaris(validate=False):
     return _get_hostname(['/bin/hostname'], validate)
 
 def get_hostname(config_override=True):
@@ -70,10 +67,7 @@ def get_hostname(config_override=True):
 
     try:
         # try fqdn
-        if platform.startswith('sunos'):
-            hostname = get_hostname_solaris()
-        else:
-            hostname = get_hostname_std()
+        hostname = get_hostname_std()
 
         if hostname:
             return hostname

--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -7,7 +7,6 @@ import re
 import logging
 import subprocess
 import socket
-from sys import platform
 
 from config import config
 

--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -38,16 +38,19 @@ def is_valid_hostname(hostname):
         return False
     return True
 
-def _get_hostname(cmd=[]):
+def _get_hostname(cmd=[], validate=False):
     fqdn = subprocess.check_output(cmd).strip()
-    if fqdn and is_valid_hostname(fqdn):
-        return fqdn
+    if fqdn:
+        if not validate:
+            return fqdn
+        elif is_valid_hostname(fqdn):
+            return fqdn
 
-def get_hostname_std():
-    return _get_hostname(['/bin/hostname', '-s'])
+def get_hostname_std(validate=False):
+    return _get_hostname(['/bin/hostname', '-s'], validate)
 
-def get_hostname_solaris():
-    return _get_hostname(['/bin/hostname'])
+def get_hostname_solaris(validate=False):
+    return _get_hostname(['/bin/hostname'], validate)
 
 def get_hostname(config_override=True):
     """

--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -39,7 +39,13 @@ def is_valid_hostname(hostname):
 
 def _get_hostname(cmd=[], validate=False):
     fqdn = subprocess.check_output(cmd).strip()
+
     if fqdn:
+        try:
+            fqdn = fqdn.decode()
+        except AttributeError:
+            pass
+
         if not validate:
             return fqdn
         elif is_valid_hostname(fqdn):

--- a/utils/tests/test_hostname.py
+++ b/utils/tests/test_hostname.py
@@ -11,10 +11,9 @@ from config import config
 
 def test_is_valid_hostname():
     assert not is_valid_hostname("localhost")
-    assert not is_valid_hostname('localhost')
-    assert not is_valid_hostname('localhost.localdomain')
-    assert not is_valid_hostname('localhost6.localdomain6')
-    assert not is_valid_hostname('ip6-localhost')
+    assert not is_valid_hostname("localhost.localdomain")
+    assert not is_valid_hostname("localhost6.localdomain6")
+    assert not is_valid_hostname("ip6-localhost")
 
     # test MAX_HOSTNAME_LEN
     assert not is_valid_hostname("a" * 256)
@@ -33,6 +32,13 @@ def test_get_hostname_conf():
 @mock.patch('subprocess.check_output', return_value="subprocess-hostname")
 def test_get_hostname_bin(subprocess):
     assert get_hostname() == "subprocess-hostname"
+
+@mock.patch('subprocess.check_output', return_value="subprocess_hostname")
+def test_get_hostname_bin(subprocess):
+    # this would fail validation if specified manually
+    # but since it's collected from the OS we let it fly
+    assert not is_valid_hostname("subprocess_hostname")
+    assert get_hostname() == "subprocess_hostname"
 
 @mock.patch("subprocess.check_output", return_value="")
 @mock.patch("socket.gethostname", return_value="socket-hostname")

--- a/utils/tests/test_hostname.py
+++ b/utils/tests/test_hostname.py
@@ -34,7 +34,7 @@ def test_get_hostname_bin(subprocess):
     assert get_hostname() == "subprocess-hostname"
 
 @mock.patch('subprocess.check_output', return_value="subprocess_hostname")
-def test_get_hostname_bin(subprocess):
+def test_get_hostname_bin_nonrfc(subprocess):
     # this would fail validation if specified manually
     # but since it's collected from the OS we let it fly
     assert not is_valid_hostname("subprocess_hostname")

--- a/utils/tests/test_hostname.py
+++ b/utils/tests/test_hostname.py
@@ -29,6 +29,10 @@ def test_get_hostname_conf():
     assert get_hostname() == "test-hostname"
     config.reset("hostname")
 
+@mock.patch('subprocess.check_output', return_value=b"subprocess-hostname")
+def test_get_hostname_bytes(subprocess):
+    assert get_hostname() == "subprocess-hostname"
+
 @mock.patch('subprocess.check_output', return_value="subprocess-hostname")
 def test_get_hostname_bin(subprocess):
     assert get_hostname() == "subprocess-hostname"


### PR DESCRIPTION
Adding support for '_' character in more flexible hostname collection. Still report if a hostname isn't RFC1123 compliant though.