### PR TITLE
[lparstats] make sure commands are run with superpowers

### DIFF
--- a/checks/bundled/lparstats/datadog_checks/lparstats/lparstats.py
+++ b/checks/bundled/lparstats/datadog_checks/lparstats/lparstats.py
@@ -24,8 +24,8 @@ class LPARStats(AgentCheck):
 
     def check(self, instance):
         sudo = instance.get('sudo', False)
-        root = running_root()
-        if not root and not sudo:
+        root = running_root() or sudo
+        if not root:
             self.log.info('Not running as root or sudo - entitlement and hypervisor metrics might be unavailable')
 
         timeout = None


### PR DESCRIPTION
Tiny fix to properly use superpowers when available.

Affects hypervisors and entitlement metric collection, see https://github.com/DataDog/datadog-unix-agent/pull/81/files#diff-ed937eae219d6b2b02b88f58da5781dfR37, for instance.