### PR TITLE
[agent] lifecycle should be managed with OS + sneaky script fix

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -315,6 +315,8 @@ def main():
                       dest='background', help='Run agent on the foreground')
     parser.add_option('-l', '--force-logging', action='store_true', default=False,
                       dest='logging', help='force logging')
+    parser.add_option('-m', '--manual', action='store_true', default=False,
+                      dest='manual', help='Apply action manually - advanced feature')
     options, args = parser.parse_args()
 
     if len(args) < 1:
@@ -343,17 +345,26 @@ def main():
     agent = Agent(PidFile(PID_NAME, pid_dir).get_path())
 
     foreground = not options.background
+    manual = options.manual
     if 'start' == command:
-        logging.info('Start daemon')
-        agent.start(foreground=foreground)
+        if manual:
+            logging.info('Start daemon')
+            agent.start(foreground=foreground)
+        else:
+            sys.stderr.write('Please use OS facilities to start the agent')
+            return 1
 
     elif 'stop' == command:
         logging.info('Stop daemon')
         agent.stop()
 
     elif 'restart' == command:
-        logging.info('Restart daemon')
-        agent.restart()
+        if manual:
+            logging.info('Restart daemon')
+            agent.restart()
+        else:
+            sys.stderr.write('Please use OS facilities to restart the agent')
+            return 1
 
     elif 'status' == command:
         agent.status(config)

--- a/agent.py
+++ b/agent.py
@@ -310,6 +310,9 @@ class Agent(Daemon):
 
 
 def main():
+    CRED = '\033[91m'
+    CEND = '\033[0m'
+
     parser = OptionParser()
     parser.add_option('-b', '--background', action='store_true', default=False,
                       dest='background', help='Run agent on the foreground')
@@ -318,21 +321,20 @@ def main():
     parser.add_option('-m', '--manual', action='store_true', default=False,
                       dest='manual', help='Apply action manually - advanced feature')
     options, args = parser.parse_args()
-
     if len(args) < 1:
         sys.stderr.write(Agent.usage())
         return 2
 
     command = args[0]
     if command not in Agent.COMMANDS:
-        sys.stderr.write("Unknown command: %s\n" % command)
+        sys.stderr.write(CRED + "Unknown command: {}\n".format(command) + CEND)
         return 3
 
     try:
         do_log = options.logging or Agent.COMMANDS[command]
         init_config(do_log=do_log)
     except Exception as e:
-        logging.error("Problem initializing configuration: %s", e)
+        logging.error(CRED + "Problem initializing configuration: {}".format(e) + CEND)
         return 1
 
     if (os.path.dirname(os.path.realpath(__file__)) != os.path.join(DEFAULT_PATH, 'agent')):
@@ -341,7 +343,11 @@ def main():
                  logs, run path, etc. And remember to drop the configuration
                  file in one of the supported locations.""" % DEFAULT_PATH)
 
-    pid_dir = config.get('run_path')
+        # if pid_dir below doesn't exist a temporary dir will be used
+        pid_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'run')
+    else:
+        pid_dir = config.get('run_path')
+
     agent = Agent(PidFile(PID_NAME, pid_dir).get_path())
 
     foreground = not options.background
@@ -351,7 +357,7 @@ def main():
             logging.info('Start daemon')
             agent.start(foreground=foreground)
         else:
-            sys.stderr.write('Please use OS facilities to start the agent')
+            sys.stderr.write(CRED + 'Please use OS facilities to start the agenti!\n' + CEND)
             return 1
 
     elif 'stop' == command:
@@ -363,7 +369,7 @@ def main():
             logging.info('Restart daemon')
             agent.restart()
         else:
-            sys.stderr.write('Please use OS facilities to restart the agent')
+            sys.stderr.write(CRED + 'Please use OS facilities to restart the agent!\n' + CEND)
             return 1
 
     elif 'status' == command:

--- a/omnibus/package-scripts/agent/aix/postinst
+++ b/omnibus/package-scripts/agent/aix/postinst
@@ -62,7 +62,7 @@ create_system_services()
     RC=$?
     set -e
     if [ "${RC}" != "0" ]; then
-        mkssys -s ${SERVICE_NAME} -p "${INSTALL_DIR}/agent/agent.py" -a "start" -u ${DATADOG_USER} -S -n 15 -f 9 > /dev/null
+        mkssys -s ${SERVICE_NAME} -p "${INSTALL_DIR}/agent/agent.py" -a "-m start" -u ${DATADOG_USER} -S -n 15 -f 9 > /dev/null
     fi
 
     # adding inittab entry if non-existant

--- a/scripts/install_script.sh
+++ b/scripts/install_script.sh
@@ -10,7 +10,7 @@ logfile="ddagent-install.log"
 
 CHANNEL=${CHANNEL:-stable}
 VERSION=${VERSION:-latest}
-AIX_ARTIFACT_SOURCE=${AIX_ARTIFACT_SOURCE:-https://s3.amazonaws.com/dd-unix-agent}
+ARTIFACT_SOURCE=${ARTIFACT_SOURCE:-https://s3.amazonaws.com/dd-unix-agent}
 SHUTDOWN_WAIT=${SHUTDOWN_WAIT:-8}  # 8 + 7 + ... + 2 + 1 secs
 
 ETCDIR="/etc/datadog-agent"
@@ -137,7 +137,7 @@ if [ "$OS" = "AIX" ]; then
 
     printf "\033[34m\n* Downloading version ${VERSION} if available...\n\033[0m\n"
     BFF="datadog-unix-agent-${VERSION}.${ARCH}.aix.${MAJOR}.${MINOR}.bff"
-    $dl_cmd -o /tmp/${BFF} ${AIX_ARTIFACT_SOURCE}/${OS_LOWER}/${CHANNEL}/${BFF}
+    $dl_cmd -o /tmp/${BFF} ${ARTIFACT_SOURCE}/${OS_LOWER}/${CHANNEL}/${BFF}
 
     INSTALLED_FILESET=$(lslpp -l "datadog-unix-agent" 2>&1 | grep -i datadog-unix-agent | awk '{ print $2 }' | head -n 1)
     CURRENT_FILESET=$(installp -ld /tmp/${BFF} 2>&1 | grep -i datadog-unix-agent | awk '{ print $2 }' | head -n 1)


### PR DESCRIPTION
Agent lifecycle should be managed with OS facilities, these might differ on different OS, including the spawning of the agent, it's shutdown, etc. Using the `start/stop` features manually should require a flag to make sure we don't interfere with the OS accidentally.

Also:
  - use a more generic name in the installer script for an env variable.
  - use color on output error messages
  - if running agent straight from source, unpackaged, use a better default location for the pid file. 