### PR TITLE
Bump psutils version

### DIFF
--- a/omnibus/config/patches/psutil/aix-net-kernel-mbuf-header-fix.patch
+++ b/omnibus/config/patches/psutil/aix-net-kernel-mbuf-header-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/psutil/arch/aix/net_kernel_structs.h b/psutil/arch/aix/net_kernel_structs.h
-index 09f320ff..8bd729db 100644
+index 4e7a088c..fd3e8d8a 100644
 --- a/psutil/arch/aix/net_kernel_structs.h
 +++ b/psutil/arch/aix/net_kernel_structs.h
 @@ -17,7 +17,7 @@
@@ -8,13 +8,13 @@ index 09f320ff..8bd729db 100644
  #include <sys/unpcb.h>
 -#include <sys/mbuf_base.h>
 +#include <sys/mbuf.h>
+ #include <sys/mbuf_macro.h>
  #include <netinet/ip_var.h>
  #include <netinet/tcp.h>
- #include <netinet/tcpip.h>
-@@ -107,4 +107,4 @@ struct mbuf64
+@@ -108,4 +108,4 @@ struct mbuf64
  
  #define m_len               m_hdr.mh_len
  
--#endif
+-#endif      /* __64BIT__ */
 \ No newline at end of file
-+#endif
++#endif      /* __64BIT__ */

--- a/omnibus/config/software/psutil.rb
+++ b/omnibus/config/software/psutil.rb
@@ -1,5 +1,5 @@
 name "psutil"
-default_version "5.6.3"
+default_version "5.6.5"
 
 python_version = ENV['PYTHON_VERSION']
 
@@ -12,8 +12,8 @@ end
 
 source :url => "https://github.com/giampaolo/psutil/archive/release-#{version}.tar.gz"
 
-version "5.6.3" do
-  source :sha256 => "55b86dc0a9fc4e258ae5d86d6edf317432a4e3dc45c7324b8a82838b07e74f4a"
+version "5.6.5" do
+  source :sha256 => "d57a81dd7cb0481819ea566c45fc5a60623ca263781a955d6d01f98d2258b964"
 end
 
 relative_path "psutil-release-#{version}"

--- a/omnibus/config/software/psutil.rb
+++ b/omnibus/config/software/psutil.rb
@@ -1,5 +1,5 @@
 name "psutil"
-default_version "5.4.6"
+default_version "5.6.3"
 
 python_version = ENV['PYTHON_VERSION']
 
@@ -12,8 +12,8 @@ end
 
 source :url => "https://github.com/giampaolo/psutil/archive/release-#{version}.tar.gz"
 
-version "5.4.6" do
-  source :sha256 => "1fbe56d7937410837ff4f8a250a9d80fcb652982982a0a2a999f906bcea4bafc"
+version "5.6.3" do
+  source :sha256 => "55b86dc0a9fc4e258ae5d86d6edf317432a4e3dc45c7324b8a82838b07e74f4a"
 end
 
 relative_path "psutil-release-#{version}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ more-itertools==4.2.0
 paramiko==2.1.6
 pbr==4.0.4
 pluggy==0.6.0
-psutil==5.4.6
+psutil==5.6.5
 py==1.5.3
 pyasn1==0.4.4
 pycparser==2.18


### PR DESCRIPTION
**What does this do:**
Bump psutils version to 5.6.5

**Motivation:**
The following fix is needed for the process agent to use getargs for AIX [Fix #1276](https://github.com/giampaolo/psutil/commit/7d8c23d5ce46eaeb13f1ca1910eabf76bdcda6a5)
That fix was released in 5.6.3, however that version was broken due to [Issue #1528](https://github.com/giampaolo/psutil/issues/1528) which got [fixed in 5.6.5](https://github.com/giampaolo/psutil/commit/9be2120e4b6f43a2450c6ddb86fbc1723dd081e5)