### PR TITLE
Fix crash when calling `status` with multiple process check

### DIFF
--- a/api/handlers.py
+++ b/api/handlers.py
@@ -80,7 +80,7 @@ class AgentStatusHandler(tornado.web.RequestHandler):
             log.debug("processing %s, %s", signature, values)
             check = signature[0]
             if check in processed:
-                processed['sources'][check]['merics'] += values
+                processed[check]['metrics'] += values
             else:
                 processed[check] = {'metrics': values}
 


### PR DESCRIPTION
### What does this PR do ?

Fix a crash when calling the `status` command with multiple process check instances, e.g.:

*process.yaml*:
```
init_config:
instances:
    - name: x-service
      search_string: ['x-service']
      exact_match: False
      tags:
        - service:x-service

    - name: y-service
      search_string: ['y-service']
      exact_match: False
      tags:
        - service:y-service
```