### PR TITLE
[docs][disk] Update docs in disk default YAML

### DIFF
--- a/checks/bundled/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/checks/bundled/disk/datadog_checks/disk/data/conf.yaml.default
@@ -20,69 +20,45 @@ instances:
   #    - <KEY_1>:<VALUE_1>
   #    - <KEY_2>:<VALUE_2>
 
-  ## @param file_system_whitelist - list of regex - optional
+  ## @param file_system_whitelist - list of string - optional
   ## Instruct the check to only collect from matching file systems.
-  ##
-  ## Character casing is ignored. For convenience, the regular expressions
-  ## start matching from the beginning and therefore to match anywhere you
-  ## must prepend `.*`. For exact matches append `$`.
   #
   #  file_system_whitelist:
-  #    - ext[34]$
-  #    - ntfs$
+  #    - ext3
+  #    - ntfs
 
-  ## @param file_system_blacklist - list of regex - optional
+  ## @param file_system_blacklist - list of string - optional
   ## Instruct the check to not collect from matching file systems.
-  ##
-  ## Character casing is ignored. For convenience, the regular expressions
-  ## start matching from the beginning and therefore to match anywhere you
-  ## must prepend `.*`. For exact matches append `$`.
   ##
   ## When conflicts arise, this will override `file_system_whitelist`.
   #
   #  file_system_blacklist:
-  #    - tmpfs$
-  #    - rootfs$
-  #    - autofs$
+  #    - tmpfs
+  #    - rootfs
+  #    - autofs
 
-  ## @param device_whitelist - list of regex - optional
+  ## @param device_whitelist - list of string - optional
   ## Instruct the check to only collect from matching devices.
-  ##
-  ## Character casing is ignored on Windows. For convenience, the regular
-  ## expressions start matching from the beginning and therefore to match
-  ## anywhere you must prepend `.*`. For exact matches append `$`.
   #
   #  device_whitelist:
-  #    - /dev/sda[1-3]
+  #    - /dev/sda1
 
-  ## @param device_blacklist - list of regex - optional
+  ## @param device_blacklist - list of string - optional
   ## Instruct the check to not collect from matching devices.
-  ##
-  ## Character casing is ignored on Windows. For convenience, the regular
-  ## expressions start matching from the beginning and therefore to match
-  ## anywhere you must prepend `.*`. For exact matches append `$`.
   ##
   ## When conflicts arise, this will override `device_whitelist`.
   #
   #  device_blacklist:
   #    - /dev/sde
 
-  ## @param mount_point_whitelist - list of regex - optional
+  ## @param mount_point_whitelist - list of string - optional
   ## Instruct the check to only collect from matching mount points.
-  ##
-  ## Character casing is ignored on Windows. For convenience, the regular
-  ## expressions start matching from the beginning and therefore to match
-  ## anywhere you must prepend `.*`. For exact matches append `$`.
   #
   #  mount_point_whitelist:
-  #    - /dev/sda[1-3]
+  #    - /dev/sda1
 
-  ## @param mount_point_blacklist - list of regex - optional
+  ## @param mount_point_blacklist - list of string - optional
   ## Instruct the check to not collect from matching mount points.
-  ##
-  ## Character casing is ignored on Windows. For convenience, the regular
-  ## expressions start matching from the beginning and therefore to match
-  ## anywhere you must prepend `.*`. For exact matches append `$`.
   ##
   ## When conflicts arise, this will override `mount_point_whitelist`.
   #


### PR DESCRIPTION
Updates to reflect that the disk check doesn't actually support regexes
in the various include/exclude lists.

Ideally, we'd want to add this feature, for now let's update the docs.