### PR TITLE
[omnibus] Pull JMXFetch JAR from Sonatype

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -16,8 +16,8 @@ end
 default_version jmxfetch_version
 source sha256: jmxfetch_hash
 
-source :url => "https://dl.bintray.com/datadog/datadog-maven/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
-        target_filename: "jmxfetch.jar"
+source url: "https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
+       target_filename: "jmxfetch.jar"
 
 jar_dir = "#{install_dir}/bin/agent/dist/jmx"
 


### PR DESCRIPTION
Bintray is shutting down. Let's pull the JAR from Sonatype, similar to what's being done in the Agent 6/7 build in https://github.com/DataDog/datadog-agent/pull/7799.

Testing: I haven't actually run an omnibus build with these changes, but I've verified the updated URL with the default jmxfetch version specified here (`0.23.0`) does point to the same JAR (same sha256 sum).