### PR TITLE
[disk] Ensure disk check runs properly when a device is inaccessible

### DIFF
--- a/checks/bundled/disk/datadog_checks/disk/disk.py
+++ b/checks/bundled/disk/datadog_checks/disk/disk.py
@@ -38,7 +38,16 @@ class Disk(AgentCheck):
             if self._exclude_partition(partition):
                 continue
 
-            disk_usage = psutil.disk_usage(partition.mountpoint)
+            try:
+                disk_usage = psutil.disk_usage(partition.mountpoint)
+            except Exception as e:
+                self.log.warning(
+                    u'Unable to get disk metrics for %s: %s. '
+                    u'You can exclude this mountpoint in the settings if it is invalid.',
+                    partition.mountpoint,
+                    e,
+                )
+                continue
             self._collect_metrics(partition, disk_usage)
 
         self._collect_io_metrics()


### PR DESCRIPTION
When a parent directory of a mountpoint of a certain device doesn't have effective `x` permissions for the `dd-agent` user, the `disk` check will raise an exception and stop its execution because of that:

```
2021-07-29 11:40:26 EDT | ERROR | dd.agent | collector.collector(collector.py:152) | Traceback disk: Traceback (most recent call last
):
  File "/opt/datadog-agent/agent/checks/agent_check.py", line 199, in run
    self.check(copy.deepcopy(self.instance))
  File "/opt/datadog-agent/embedded/lib/python3.6/site-packages/datadog_checks/disk/disk.py", line 41, in check
    try:
  File "/opt/datadog-agent/embedded/lib/python3.6/site-packages/psutil/__init__.py", line 2013, in disk_usage
    return _psplatform.disk_usage(path)
  File "/opt/datadog-agent/embedded/lib/python3.6/site-packages/psutil/_psposix.py", line 121, in disk_usage
    st = os.statvfs(path)
PermissionError: [Errno 13] Permission denied: '/var/adm/ras/livedump'
```

This PR ensures that we just log a warning message and continue the execution of the check.

This would however only work with `all_partitions: true` set in the check config. With `all_partitions: false` it would still fail with a similar error because of this line: https://github.com/giampaolo/psutil/blob/c6cd256da95ffe9599792759b1c2586ba24fa047/psutil/_psaix.py#L194 - which we'd need to fix in psutil (but AFAICT that'd also fail in the standard version of the check, so maybe that's not worth it).