### PR TITLE
Support both dogstatsd.enable and dogstatsd.enabled

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -249,7 +249,7 @@ class Agent(Daemon):
         dsd_server = None
         dsdconf = config['dogstatsd']
         # 'enable' was a typo, kept for backwards compatibility
-        dsd_enable = dsdconf.get('enabled', False) || dsdconf.get('enable', False)
+        dsd_enable = dsdconf.get('enabled', False) or dsdconf.get('enable', False)
         if dsd_enable:
             reporter, dsd_server, _ = init_dogstatsd(config, forwarder=forwarder)
             dsd = DogstatsdRunner(dsd_server)

--- a/agent.py
+++ b/agent.py
@@ -247,7 +247,9 @@ class Agent(Daemon):
         # instantiate Dogstatsd
         reporter = None
         dsd_server = None
-        dsd_enable = config['dogstatsd'].get('enable', False)
+        dsdconf = config['dogstatsd']
+        # 'enable' was a typo, kept for backwards compatibility
+        dsd_enable = dsdconf.get('enabled', False) || dsdconf.get('enable', False)
         if dsd_enable:
             reporter, dsd_server, _ = init_dogstatsd(config, forwarder=forwarder)
             dsd = DogstatsdRunner(dsd_server)


### PR DESCRIPTION
The example yaml uses `enabled`, so it was probably a typo that we check for `enable`.