### PR TITLE
Release version 1.1.6

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -43,7 +43,7 @@ from dogstatsd.helpers import (
 
 
 # Globals
-AGENT_VERSION = '1.1.4'
+AGENT_VERSION = '1.1.6'
 PID_NAME = 'datadog-unix-agent'
 
 log = logging.getLogger('agent')


### PR DESCRIPTION
We failed to update `AGENT_VERSION` for 1.1.5, so let's release a new version 1.1.6 in which the version is going to be correct.