### PR TITLE
Upgrade linters and fix new linting issues

### DIFF
--- a/aggregator/tests/test_aggregator.py
+++ b/aggregator/tests/test_aggregator.py
@@ -661,7 +661,7 @@ class TestMetricsAggregator():
         try:
             first['tags']
         except Exception:
-                assert True
+            assert True
         else:
             assert False, "event['tags'] shouldn't be defined when no tags aren't explicited in the packet"
         assert first['msg_title'] == 'title1'

--- a/checks/bundled/hmc/datadog_checks/hmc/hmc.py
+++ b/checks/bundled/hmc/datadog_checks/hmc/hmc.py
@@ -301,7 +301,7 @@ class HMC(AgentCheck):
         except Exception:
             raise
 
-        lines = [l for l in stdout.read().splitlines() if re.search('DS |RM ', l)]
+        lines = [ln for ln in stdout.read().splitlines() if re.search('DS |RM ', ln)]
         if not lines:
             return None
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 mccabe==0.6.1
-flake8==3.6.0
-pyflakes==2.0.0
+flake8==4.0.1
+pyflakes==2.4.0
 pytest==3.6.2
 pylint==2.3.1
 termcolor==1.1.0

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -190,7 +190,7 @@ def lint_releasenote(ctx):
         # first check 'changelog/no-changelog' label
         res = requests.get("https://api.github.com/repos/DataDog/datadog-unix-agent/issues/{}".format(pr_id))
         issue = res.json()
-        if any([l['name'] == 'changelog/no-changelog' for l in issue.get('labels', {})]):
+        if any([label['name'] == 'changelog/no-changelog' for label in issue.get('labels', {})]):
             print("'changelog/no-changelog' label found on the PR: skipping linting")
             return
 

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -4,7 +4,7 @@
 # Copyright 2018 Datadog, Inc.
 
 def skip_blank_lines(f):
-    for l in f:
-        line = l.rstrip()
+    for ln in f:
+        line = ln.rstrip()
         if line:
             yield line


### PR DESCRIPTION
Linters broke on main, so I upgraded them to latest versions - the most notable change is that flake8 doesn't like when a variable is called `l`.