### PR TITLE
Address vuln in HMC check

### DIFF
--- a/checks/bundled/hmc/datadog_checks/hmc/data/conf.yaml.example
+++ b/checks/bundled/hmc/datadog_checks/hmc/data/conf.yaml.example
@@ -9,6 +9,4 @@ instances:
     password: bar                           # optional: password for username @ hmc appliance
     private_key_file: /etc/ssh/somekey.pem  # optional: key authentication - path to private key
     private_key_type: rsa                   # optional: key type (rsa, ecdsa)
-    add_missing_keys: false                 # optional: boolean indicating if missing keys should 
-                                            #           be added to the SSH agent
 

--- a/checks/bundled/hmc/datadog_checks/hmc/hmc.py
+++ b/checks/bundled/hmc/datadog_checks/hmc/hmc.py
@@ -67,7 +67,6 @@ class HMC(AgentCheck):
         ('password', False, None, str),
         ('private_key_file', False, None, str),
         ('private_key_type', False, 'rsa', str),
-        ('add_missing_keys', False, False, bool),
     ]
 
     Config = namedtuple('Config', [
@@ -77,7 +76,6 @@ class HMC(AgentCheck):
         'password',
         'private_key_file',
         'private_key_type',
-        'add_missing_keys',
     ])
 
     # HMC environments
@@ -208,8 +206,7 @@ class HMC(AgentCheck):
                 self.warning("Private key file is invalid")
 
         client = paramiko.SSHClient()
-        if conf.add_missing_keys:
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.set_missing_host_key_policy(paramiko.RejectPolicy())
         client.load_system_host_keys()
 
         exception_message = "No errors occured"

--- a/checks/bundled/hmc/tests/test_hmc.py
+++ b/checks/bundled/hmc/tests/test_hmc.py
@@ -28,7 +28,6 @@ def get_config_stubs():
             'password': None,
             'private_key_file': 'id_rsa',
             'private_key_type': 'rsa',
-            'add_missing_keys': [],
         }
     }]
 


### PR DESCRIPTION
This PR disables the acceptance of unknown host keys, as they can allow man-in-the-middle attacks.