### PR TITLE
Fix process check crashes due to uncaught psutil.AccessDenied exceptions

### DIFF
--- a/checks/bundled/process/datadog_checks/process/__about__.py
+++ b/checks/bundled/process/datadog_checks/process/__about__.py
@@ -3,4 +3,4 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## What does this PR do?
- Adds comprehensive `psutil.AccessDenied` exception handling across all process access methods
- Fixes crashes in `_filter_by_user()` when querying processes owned by other users
- Fixes crashes in `_get_child_processes()` when collecting children of privileged processes
- Fixes crashes in `_get_pid_set()` when accessing restricted processes
- Fixes crashes in `get_process_state()` when checking if cached processes are still running
- Bumps version from 0.1.0 to 0.2.0

### Before

```
  - process
    -------
    instance (0x899d418afa29a019):

        Error: psutil.AccessDenied (pid=4260238)

        Traceback (most recent call last):
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 340, in wrapper
              ret = self._cache[fun]
          AttributeError: 'Process' object has no attribute '_cache'

          During handling of the above exception, another exception occurred:

          Traceback (most recent call last):
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 340, in wrapper
              ret = self._cache[fun]
          AttributeError: _cache

          During handling of the above exception, another exception occurred:

          Traceback (most recent call last):
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_psaix.py", line 318, in wrapper
              return fun(self, *args, **kwargs)
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 343, in wrapper
              return fun(self)
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_psaix.py", line 359, in _proc_cred
              return cext.proc_cred(self.pid, self._procfs_path)
          PermissionError: [Errno 13] Permission denied: '/proc/4260238/cred'

          During handling of the above exception, another exception occurred:

          Traceback (most recent call last):
            File "/opt/datadog-agent/agent-fix_process_accessdenied-00cec7dca6/checks/agent_check.py", line 202, in run
              self.check(copy.deepcopy(self.instance))
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/process/process.py", line 308, in check
              pids = self._filter_by_user(user, pids)
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/process/process.py", line 387, in _filter_by_user
              if proc.username() == user:
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/__init__.py", line 809, in username
              real_uid = self.uids().real
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 343, in wrapper
              return fun(self)
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/__init__.py", line 847, in uids
              return self._proc.uids()
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_psaix.py", line 318, in wrapper
              return fun(self, *args, **kwargs)
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_psaix.py", line 457, in uids
              real, effective, saved, _, _, _ = self._proc_cred()
            File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_psaix.py", line 328, in wrapper
              raise AccessDenied(self.pid, self._name)
          psutil.AccessDenied: psutil.AccessDenied (pid=4260238)
instance (0x7ebf8b70771d68f4):

```

### After

```
  process
  -------
    Instance ID: process:6851783a59e73cd0
    Configuration Source: file:/etc/datadog-agent/conf.d/process.d/test_access_denied.yaml[0]
    Total Runs: 2
    Metric Samples: Last Run: 1
    Events: Last Run: 0
    Service Checks: Last Run: 1
    Average Execution Time: 161ms
    Last Execution Date: 2026-01-28 23:18:59.120 UTC (ts: 1769663939120)
```

---

## Motivation
- **Reliability:** `psutil.AccessDenied` exceptions were not properly caught in several methods, causing the check to crash when querying processes owned by other users (e.g., root-owned processes when running as `dd-agent` user)
- **Critical Impact:** On AIX and other Unix systems with strict process access controls, the process check would fail completely when monitoring system processes like `sshd`, `syslogd`, or `snmpd` if `ignore_denied_access: false` was set

**Crash locations fixed:**
```
1. _filter_by_user() → proc.username() raises AccessDenied
2. _get_child_processes() → proc.children() raises AccessDenied
3. _get_pid_set() → psutil.Process(pid) raises AccessDenied
4. get_process_state() → is_running() raises AccessDenied
5. get_process_state() → psutil.Process(pid) raises AccessDenied
```

**Impact:** Process check no longer crashes when encountering access-restricted processes, improving reliability when monitoring mixed privileged/unprivileged processes on Unix systems.



---

## Describe how you validated your changes
- **Unit tests:** All 10 existing tests pass without modification
- **Manual testing on AIX:**
  - Tested as `dd-agent` user querying root-owned processes (sshd, syslogd, snmpd, etc.)
  - Confirmed `AccessDenied` exceptions are now properly caught and logged at debug level
  - Verified the check continues running and collects metrics for accessible processes
  - Tested configurations with `collect_children`, `user` filtering, and `pid_file` lookups
- **Backwards compatibility:** No breaking changes to configuration or behavior, only improved error handling

---

<details>
<summary><b>Test Results</b></summary>

```
============================= test session starts ==============================
platform linux -- Python 3.7.17, pytest-3.6.2, py-1.10.0, pluggy-0.6.0 -- /opt/datadog-agent/venv/bin/python
cachedir: checks/bundled/process/.pytest_cache
rootdir: /opt/datadog-agent-local/checks/bundled/process, inifile: pytest.ini
plugins: requests-mock-1.5.2
collecting ... collected 10 items

checks/bundled/process/tests/test_process.py::test_psutil_wrapper_simple PASSED [ 10%]
checks/bundled/process/tests/test_process.py::test_psutil_wrapper_simple_fail PASSED [ 20%]
checks/bundled/process/tests/test_process.py::test_psutil_wrapper_accessors PASSED [ 30%]
checks/bundled/process/tests/test_process.py::test_psutil_wrapper_accessors_fail PASSED [ 40%]
checks/bundled/process/tests/test_process.py::test_ad_cache PASSED       [ 50%]
checks/bundled/process/tests/test_process.py::test_check PASSED          [ 60%]
checks/bundled/process/tests/test_process.py::test_check_collect_children PASSED [ 70%]
checks/bundled/process/tests/test_process.py::test_check_filter_user PASSED [ 80%]
checks/bundled/process/tests/test_process.py::test_check_missing_pid PASSED [ 90%]
checks/bundled/process/tests/test_process.py::test_check_real_process PASSED [100%]

========================== 10 passed in 0.10 seconds ===========================
```
</details>