### PR TITLE
Fix integration & config error display in agent status

### DIFF
--- a/api/handlers.py
+++ b/api/handlers.py
@@ -31,17 +31,19 @@ class AgentStatusHandler(tornado.web.RequestHandler):
         status = {}
         check_stats = {}
 
-        # First pass: extract consolidated check stats from collector if available
+        # First pass: extract consolidated check stats and runtime errors from collector if available
+        runtime_errors = {}
         if 'collector' in self._status:
             _, collector_info = self._status['collector'].snapshot()
             check_stats = collector_info.get('check_stats', {})
+            runtime_errors = collector_info.get('runtime_errors', {})
 
         # Second pass: process all components
         for component, stats in self._status.items():
             log.debug("adding component %s to stats", component)
             stats_snap, info_snap = stats.snapshot()
             if component == 'agent':
-                info_snap = self.process_agent_info(info_snap, check_stats)
+                info_snap = self.process_agent_info(info_snap, check_stats, runtime_errors)
             elif component == 'collector':
                 info_snap = self.process_collector_info(info_snap)
 
@@ -74,6 +76,7 @@ class AgentStatusHandler(tornado.web.RequestHandler):
 
         status['redacted_api'] = mask_api_key_value(self._config.get('api_key'))
         status['api_status'] = validate_api_key(self._config)
+        status['config_errors'] = self._config.get_config_errors()
 
         try:
             log.debug('status response to render: %s', status)
@@ -81,10 +84,12 @@ class AgentStatusHandler(tornado.web.RequestHandler):
         except TypeError as e:
             log.error("unable to handle status request: %s", e)
 
-    def process_agent_info(self, info, check_stats=None):
+    def process_agent_info(self, info, check_stats=None, runtime_errors=None):
         processed = {}
         if check_stats is None:
             check_stats = {}
+        if runtime_errors is None:
+            runtime_errors = {}
 
         # Process metrics by instance (signature)
         for signature, values in info.get('sources', {}).items():
@@ -222,6 +227,47 @@ class AgentStatusHandler(tornado.web.RequestHandler):
                     'total_runs': runs,
                     'last_execution': last_exec_display
                 }
+
+        # Merge runtime errors into existing stats (add error_message/traceback, or create entry if missing)
+        for check_name, errors in runtime_errors.items():
+            for signature_hash, error in errors.items():
+                stats = check_stats.get(signature_hash, {})
+                instance_name = stats.get('instance_name')
+                if instance_name:
+                    instance_id = "{}:{}:{}".format(check_name, instance_name, format(signature_hash, 'x'))
+                else:
+                    instance_id = "{}:{}".format(check_name, format(signature_hash, 'x'))
+
+                if instance_id in processed:
+                    processed[instance_id]['error_message'] = error.get('message', '')
+                    processed[instance_id]['traceback'] = error.get('traceback', '')
+                else:
+                    config_source = stats.get('config_source', 'unknown')
+                    instance_index = stats.get('instance_index', 0)
+                    total_runs = stats.get('total_runs', 0)
+                    exec_times_list = stats.get('execution_times', [])
+                    avg_exec_time = sum(exec_times_list) / len(exec_times_list) if exec_times_list else 0
+                    last_exec = stats.get('last_execution')
+                    if last_exec:
+                        last_exec_str = last_exec.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + " UTC"
+                        last_exec_ts = int(last_exec.timestamp() * 1000)
+                        last_exec_display = "{} (ts: {})".format(last_exec_str, last_exec_ts)
+                    else:
+                        last_exec_display = "Never"
+                    processed[instance_id] = {
+                        'check_name': check_name,
+                        'signature_hash': signature_hash,
+                        'config_source': config_source,
+                        'instance_index': instance_index,
+                        'metrics': 0,
+                        'events': 0,
+                        'service_checks': 0,
+                        'avg_execution_time_ms': round(avg_exec_time, 0),
+                        'total_runs': total_runs,
+                        'last_execution': last_exec_display,
+                        'error_message': error.get('message', ''),
+                        'traceback': error.get('traceback', ''),
+                    }
 
         return {'checks': processed}
 

--- a/config/config.py
+++ b/config/config.py
@@ -274,3 +274,11 @@ class Config(object):
 
     def get_check_configs(self):
         return self._check_configs
+
+    def get_config_errors(self):
+        """Return list of config load errors from all providers for status display."""
+        errors = []
+        for provider in self._providers.values():
+            if hasattr(provider, 'get_config_errors'):
+                errors.extend(provider.get_config_errors())
+        return errors

--- a/config/providers/file.py
+++ b/config/providers/file.py
@@ -24,7 +24,12 @@ class FileConfigProvider(ConfigProvider):
 
     def __init__(self):
         self._places = set()
+        self._config_errors = []
         super(FileConfigProvider, self).__init__()
+
+    def get_config_errors(self):
+        """Return list of config load errors for status display."""
+        return list(self._config_errors)
 
     def add_place(self, place):
         if not os.path.isdir(place):
@@ -36,6 +41,7 @@ class FileConfigProvider(ConfigProvider):
     def collect(self):
         configs = defaultdict(list)
         defaults = defaultdict(list)
+        self._config_errors = []
 
         config_yamls = self._get_config_yamls()
         for config_path, config_file, is_default in config_yamls:
@@ -59,10 +65,25 @@ class FileConfigProvider(ConfigProvider):
                     yaml_config = yaml.safe_load(stream)
                 except yaml.YAMLError as e:
                     log.warn('unable to load YAML for %s: %s', yaml_path, e)
+                    err_msg = str(e).split('\n')[0].strip()
+                    if hasattr(e, 'problem_mark') and e.problem_mark is not None:
+                        message = 'yaml: line {}: {}'.format(e.problem_mark.line + 1, err_msg)
+                    else:
+                        message = err_msg
+                    self._config_errors.append({
+                        'check': check,
+                        'file': config_file,
+                        'message': message,
+                    })
                     continue
 
                 if not self.validate_config(yaml_config):
                     log.warn('bad configuration YAML in %s', yaml_path)
+                    self._config_errors.append({
+                        'check': check,
+                        'file': config_file,
+                        'message': 'bad configuration YAML',
+                    })
                     continue
 
             place = None

--- a/config/providers/provider.py
+++ b/config/providers/provider.py
@@ -16,3 +16,7 @@ class ConfigProvider(object):
             return False
 
         return 'instances' in config
+
+    def get_config_errors(self):
+        '''Return list of config load errors for status display. Default: empty.'''
+        return []

--- a/templates/status.jinja
+++ b/templates/status.jinja
@@ -40,7 +40,7 @@ Running Checks
   {{ check_name }}
   {{ '-'*check_name|length }}
   {%- for instance_id, stats in checks_by_name[check_name]|sort %}
-    Instance ID: {{ instance_id }}
+    Instance ID: {{ instance_id }}{% if stats.get('error_message') %} [ERROR]{% else %} [OK]{% endif %}
     Configuration Source: file:{{ stats.get('config_source', 'unknown') }}[{{ stats.get('instance_index', 0) }}]
     Total Runs: {{ "{:,}".format(stats.get('total_runs', 0)) }}
     Metric Samples: Last Run: {{ stats.get('metrics', 0) }}
@@ -48,23 +48,38 @@ Running Checks
     Service Checks: Last Run: {{ stats.get('service_checks', 0) }}
     Average Execution Time: {{ stats.get('avg_execution_time_ms', 0)|int }}ms
     Last Execution Date: {{ stats.get('last_execution', 'Never') }}
+{% if stats.get('error_message') %}
+    Error: {{ stats.get('error_message') }}
+
+    {{ stats.get('traceback', '')|indent(width=4) }}
+{% endif -%}
 {{ '' }}
   {%- endfor %}
 {%- endfor %}
 {%- else -%}
   There are currently no running checks.
 {% endif -%}
-{% for check, errors in collector.get('info').get('errors').get('runtime', {}).items() %}
-  - {{ check }}
-    {{ '-'*check|length }}
-    {% for instance, error in errors.items() -%}
-    instance ({{ instance }}):
 
-        Error: {{ error.get('message') }}
-
-        {{ error.get('traceback', '')|indent(width=10) -}}
-    {% endfor -%}
-{% endfor %}
+{% if status.get('config_errors') %}
+Config Errors
+=============
+{%- set config_errors_by_check = {} %}
+{%- for err in status.get('config_errors', []) %}
+  {%- set check_name = err.get('check', 'unknown') %}
+  {%- if check_name not in config_errors_by_check %}
+    {%- set _ = config_errors_by_check.update({check_name: []}) %}
+  {%- endif %}
+  {%- set _ = config_errors_by_check[check_name].append({'file': err.get('file', ''), 'message': err.get('message', '')}) %}
+{%- endfor %}
+  {%- for check_name in config_errors_by_check|sort %}
+    {{ check_name }}
+    {{ '-'*check_name|length }}
+  {%- for item in config_errors_by_check[check_name] %}
+      {{ item.file + ': ' if item.file else '' }}{{ item.message }}
+  {%- endfor %}
+{{ '' }}
+{%- endfor %}
+{%- endif %}
 
 Aggregator
 ==========
@@ -74,7 +89,6 @@ Aggregator
   Service Check: {{ "{:,}".format(agent.get('stats', {}).get('service_checks', 0)) }}
   Service Checks Flushed: {{ "{:,}".format(agent.get('stats', {}).get('service_checks_total', 0)) }}
   Series Flushed: {{ "{:,}".format(agent.get('stats', {}).get('metrics_total', 0)) }}
-
 {% if collector.get('info').get('errors').get('loader', {})|length > 0 -%}
 Errors
 ======
@@ -86,7 +100,6 @@ Errors
     {% endfor -%}
 {%- endfor %}
 {%- endif %}
-
 Forwarder
 =========
   Submitted Series Payloads: {{ "{:,}".format(forwarder.get('stats', {}).get('series_payloads', 0)) }}
@@ -95,7 +108,6 @@ Forwarder
   Transactions Submitted: {{ "{:,}".format(forwarder.get('stats', {}).get('transactions_success', 0)) }}
   Transactions Rescheduled: {{ "{:,}".format(forwarder.get('stats', {}).get('transactions_rescheduled', 0)) }}
   Full Queue Errors: {{ "{:,}".format(forwarder.get('stats', {}).get('queue_full_errors', 0)) }}
-
 {% if dogstatsd|length > 0 %}
 Dogstatsd
 =========
@@ -108,7 +120,6 @@ Dogstatsd
   Total Service Check Count: {{ "{:,}".format(dogstatsd.get('stats', {}).get('service_checks_total', 0)) }}
   Total Packet Count: {{ "{:,}".format(dogstatsd.get('stats', {}).get('packets_total', 0)) }}
 {% endif %}
-
 API Key Status
 ==============
   API Key ending in {{ status.get('redacted_api') }}: {{ status.get('api_status') }}


### PR DESCRIPTION
## What does this PR do?
- Properly surfaces integration runtime errors in agent status
- Adds a **Config Errors** section for YAML parse and validation failures (check name, filename, short message)

**Before**
```
  - ibm_was
    -------
    instance (0x7625b39d8031684d):

        Error: HTTPConnectionPool(host='localhost', port=1234): Max retries exceeded with url: /wasPerfTool/servlet/perfservlet (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xa00000001077be0>: Failed to establish a new connection: [Errno 79] Connection refused'))
```

**After**
```
  ibm_was
  ------
    Instance ID: ibm_was:xxxx
    Configuration Source: file:/etc/datadog-agent/conf.d/ibm_was.d/conf.yaml[0]
    Total Runs: 1
    Metric Samples: Last Run: 1
    Events: Last Run: 0
    Service Checks: Last Run: 0
    Average Execution Time: 55ms
    Last Execution Date: 2026-02-13 04:45:23.569 UTC (ts: 1770957923569)

    Error: HTTPConnectionPool(host='localhost', port=1234): Max retries exceeded with url: /wasPerfTool/servlet/perfservlet (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xa00000001077be0>: Failed to establish a new connection: [Errno 79] Connection refused'))
    
Config Errors  <--ADDED
=============
    ntp
    ---
      conf.yaml: yaml: line 8: while parsing a block mapping
```

## Motivation
- yaml syntax errors are not surfaced in `agent status`

## Describe how you validated your changes
- **Unit tests:** All 223 tests pass (including `api/tests/test_handlers.py` and `config/tests/`) without modification
- **Manual testing (AIX):**
  - Introduced YAML syntax errors and invalid config (missing `instances`); confirmed Config Errors section shows check name, filename (e.g. conf.yaml), and short message (e.g. `yaml: line N: ...` or `bad configuration YAML`)
