### PR TITLE
Honor NO_PROXY for outbound HTTP; align proxy stack with main Agent

### DIFF
--- a/datadog.yaml.example
+++ b/datadog.yaml.example
@@ -57,12 +57,15 @@ api_key: <api_key_here>                     # Datadog API key (required)
 #                                     # If not set, uses system defaults (HTTP_PROXY env var).
 #   https: http://localhost:3128      # HTTPS proxy.
 #                                     # If not set, uses system defaults (HTTPS_PROXY env var).
-#   no_proxy: datadoghq.com,localhost,127.0.0.1,169.254.169.254
-#                                     # Comma-separated list of hosts that bypass the proxy.
-#                                     # Defaults to:
-#                                     #   - 127.0.0.1
-#                                     #   - localhost
-#                                     #   - 169.254.169.254
+#   no_proxy:                         # Hosts that bypass the proxy (YAML list).
+#     - .datadoghq.com
+#     - localhost
+#     - 127.0.0.1
+#     - 169.254.169.254
+#                                     # If NO_PROXY / no_proxy is set in the environment, that value
+#                                     # is used alone (comma/semicolon split). Otherwise this list is
+#                                     # used and 127.0.0.1, localhost, 169.254.169.254 are appended
+#                                     # unless the list contains '*' (bypass-all for that path).
 
 # ---------------------------------------------------------------------------
 # DogStatsD configuration

--- a/utils/http.py
+++ b/utils/http.py
@@ -8,7 +8,7 @@ from config import config
 from config.config import AGENT_VERSION
 from typing import Optional
 from urllib.parse import urlparse
-from utils.network import get_proxy
+from utils.network import get_proxy, should_bypass_proxy
 from utils.util import _is_affirmative
 from utils.strip import mask_api_key_value
 
@@ -26,6 +26,17 @@ log = logging.getLogger(__name__)
 # -------------------------------------------------------------------
 MAX_COMPRESSED_SIZE = 2 << 20  # 2 MB – conservative limit
 MAX_SPLIT_DEPTH = 2            # for future payload-splitting logic
+
+
+def _no_proxy_uri_list(proxies):
+    """Split ``no`` / ``no_proxy`` from a requests ``proxies`` dict into tokens."""
+    raw = proxies.get("no_proxy") or proxies.get("no")
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple)):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    raw = str(raw).replace(";", ",")
+    return [p.strip() for p in raw.split(",") if p.strip()]
 
 
 def _compress_with_zstd(data: bytes, level: Optional[int] = None):
@@ -199,12 +210,6 @@ class RequestsWrapper:
         if "DD-API-KEY" in safe_headers:
             safe_headers["DD-API-KEY"] = mask_api_key_value(safe_headers["DD-API-KEY"])
 
-        # Debug request configuration
-        log.debug(
-            "[HTTP] %s %s; verify=%s; proxies=%s; timeout=%s; headers=%s",
-            method, url, merged["verify"], merged["proxies"], merged["timeout"], safe_headers,
-        )
-
         # ----------------------------------------------------------------------
         # Optional payload compression (POST/PUT with data)
         # ----------------------------------------------------------------------
@@ -248,6 +253,20 @@ class RequestsWrapper:
             merged["data"] = data
 
         merged["headers"] = headers
+
+        # requests.adapters.HTTPAdapter uses select_proxy(), which ignores no_proxy
+        # when http/https keys are present. Clear scheme proxies when bypass matches.
+        # Bypass rules follow integrations-core should_bypass_proxy (#5081).
+        proxies = merged.get("proxies")
+        if proxies:
+            no_proxy_uris = _no_proxy_uri_list(proxies)
+            if no_proxy_uris and should_bypass_proxy(url, no_proxy_uris):
+                merged["proxies"] = {**proxies, "http": None, "https": None}
+
+        log.debug(
+            "[HTTP] %s %s; verify=%s; proxies=%s; timeout=%s; headers=%s",
+            method, url, merged["verify"], merged["proxies"], merged["timeout"], safe_headers,
+        )
 
         # ----------------------------------------------------------------------
         # Actual HTTP request with safe error handling

--- a/utils/network.py
+++ b/utils/network.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
+import ipaddress
 import os
 import socket
 import logging
@@ -19,6 +20,132 @@ IPV6_DISABLED_ERR = "IPv6 is disabled"
 LOCAL_PROXY_SKIP = ["127.0.0.1", "localhost", "169.254.169.254"]
 
 log = logging.getLogger(__name__)
+
+
+def _dd_proxy_env(name):
+    """Read ``DD_PROXY_*``; treat empty string as unset. Uppercase fallback only."""
+    v = os.environ.get(name)
+    if v and str(v).strip():
+        return v
+    u = name.upper()
+    v = os.environ.get(u)
+    if v and str(v).strip():
+        return v
+    return None
+
+
+def _resolve_proxy_scheme(dd_env_name, yaml_value, getproxies_dict, scheme_key):
+    """
+    Per-scheme proxy URL precedence::
+
+        ``dd_env_name`` (e.g. ``DD_PROXY_HTTPS``)
+        > ``yaml_value`` (``proxy.https`` in datadog.yaml)
+        > ``getproxies_dict[scheme_key]`` (from ``HTTPS_PROXY`` / ``https_proxy`` / …).
+
+    ``scheme_key`` is ``'http'`` or ``'https'`` as returned by ``urllib.request.getproxies()``.
+    """
+    return _dd_proxy_env(dd_env_name) or yaml_value or getproxies_dict.get(scheme_key)
+
+
+def _split_dd_proxy_no_proxy(value):
+    """
+    Parse ``DD_PROXY_NO_PROXY``: comma/semicolon like ``NO_PROXY``, or
+    whitespace-separated (Datadog docs) when no comma/semicolon present.
+    """
+    if value is None:
+        return []
+    s = str(value).strip()
+    if not s:
+        return []
+    if ',' in s or ';' in s:
+        return _split_no_proxy_env_string(s)
+    return [p for p in s.split() if p]
+
+
+def _split_no_proxy_env_string(value):
+    """
+    Split a NO_PROXY / no_proxy environment-style value on commas and semicolons.
+    (Only env and getproxies() ``no`` use this; datadog.yaml ``no_proxy`` uses a list.)
+    """
+    if value is None:
+        return []
+    s = str(value).strip()
+    if not s:
+        return []
+    out = []
+    for part in s.replace(';', ',').split(','):
+        p = part.strip()
+        if p:
+            out.append(p)
+    return out
+
+
+def _no_proxy_yaml_tokens(val):
+    """
+    Tokens from ``proxy.no_proxy`` in datadog.yaml: a YAML list, or one literal
+    string (commas are not split — use a list for multiple hosts).
+    """
+    if val is None:
+        return []
+    if isinstance(val, (list, tuple)):
+        return [str(x).strip() for x in val if str(x).strip()]
+    s = str(val).strip()
+    return [s] if s else []
+
+
+def should_bypass_proxy(url, no_proxy_uris):
+    """
+    Return True if ``url`` should bypass HTTP(S) proxies for the given
+    ``no_proxy_uris`` (list of tokens, e.g. from NO_PROXY / proxy.no_proxy).
+
+    Semantics follow ``datadog_checks.base.utils.http`` in integrations-core
+    (DataDog/integrations-core#5081 and successors):
+
+    - A list entry ``*`` matches all hosts (curl-style NOPROXY).
+    - ``unix`` scheme URLs bypass (no HTTP proxy).
+    - Tokens parsed as IPv4/IPv6 networks (``ipaddress``) match the URL host
+      when it is a valid IP in that network (CIDR / netmask forms supported).
+    - Otherwise tokens are host / domain rules: ``example.com`` matches that
+      host and subdomains; a leading ``.`` or ``*.`` matches subdomains only
+      (``.y.com`` matches ``x.y.com`` but not ``y.com``).
+    """
+    if not no_proxy_uris:
+        return False
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+
+    if '*' in no_proxy_uris:
+        return True
+
+    if parsed.scheme == 'unix':
+        return True
+
+    if not host:
+        return False
+
+    host = host.lower()
+
+    for raw_rule in no_proxy_uris:
+        no_proxy_uri = (raw_rule or '').strip()
+        if not no_proxy_uri:
+            continue
+
+        try:
+            net = ipaddress.ip_network(no_proxy_uri, strict=False)
+            addr = ipaddress.ip_address(host)
+            if addr in net:
+                return True
+        except ValueError:
+            rule = no_proxy_uri.lower()
+            if rule.startswith(('.', '*.')):
+                dot_no_proxy_uri = rule.lstrip('*')
+            else:
+                dot_no_proxy_uri = '.{}'.format(rule)
+            if rule == host or host.endswith(dot_no_proxy_uri):
+                return True
+
+    return False
 
 
 def ipv6_support():
@@ -81,39 +208,72 @@ def get_socket_address(host, port, ipv4_only=False):
     return sockaddr
 
 
-def set_no_proxy_settings(proxy_settings):
+def set_no_proxy_settings(proxy_settings, cfg_proxy):
+    """
+    Resolve ``no_proxy`` precedence (same stack as ``DD_PROXY_HTTP`` / main Agent):
 
-    no_proxy = os.environ.get('no_proxy', os.environ.get('NO_PROXY', None))
+    1. ``DD_PROXY_NO_PROXY`` — if set (non-empty), use only that (parsed).
+    2. Else ``proxy.no_proxy`` from datadog.yaml (YAML list or one literal string).
+    3. Else ``NO_PROXY`` / ``no_proxy`` environment variables.
 
-    if no_proxy is None or not no_proxy.strip():
-        no_proxy = []
+    Then append ``LOCAL_PROXY_SKIP`` unless the chosen list contains ``*``.
+    """
+    dd_np = _dd_proxy_env('DD_PROXY_NO_PROXY')
+    if dd_np and str(dd_np).strip():
+        no_proxy = list(_split_dd_proxy_no_proxy(dd_np))
+    elif cfg_proxy.get('no_proxy') is not None:
+        no_proxy = list(_no_proxy_yaml_tokens(cfg_proxy.get('no_proxy')))
     else:
-        no_proxy = no_proxy.split(',')
+        no_proxy = list(_split_no_proxy_env_string(
+            os.environ.get('no_proxy') or os.environ.get('NO_PROXY') or ''
+        ))
 
-    for host in LOCAL_PROXY_SKIP:
-        if host not in no_proxy:
-            no_proxy.append(host)
+    bypass_all = '*' in no_proxy
+    if not bypass_all:
+        for host in LOCAL_PROXY_SKIP:
+            if host not in no_proxy:
+                no_proxy.append(host)
 
-    for host in [_f for _f in proxy_settings.get('no_proxy', '').split(',') if _f]:
-        if host not in no_proxy:
-            no_proxy.append(host)
-
-    proxy_settings['no_proxy'] = ','.join(no_proxy)
-    os.environ['no_proxy'] = proxy_settings['no_proxy']
+    merged = ','.join(no_proxy)
+    proxy_settings['no_proxy'] = merged
+    os.environ['no_proxy'] = merged
+    # Avoid duplicating urllib's `no` key; requests ignores both for scheme proxies
+    # until http.RequestsWrapper clears http/https. Single key keeps logs/config clear.
+    proxy_settings.pop('no', None)
 
 
 def get_proxy():
-    proxy_settings = config.get('proxy', {})
+    """
+    HTTP/HTTPS proxy URL precedence (each scheme independently), aligned with the
+    main Datadog Agent / docs::
 
-    # if nothing was set, use OS-level proxies
-    if not proxy_settings or \
-            not (proxy_settings.get('http') or proxy_settings.get('https')):
-        proxy_settings = getproxies()
+        ``DD_PROXY_HTTP``  > ``proxy.http``  (datadog.yaml) > ``http_proxy`` / ``HTTP_PROXY`` / …
+        ``DD_PROXY_HTTPS`` > ``proxy.https`` (datadog.yaml) > ``https_proxy`` / ``HTTPS_PROXY`` / …
 
-    # allow anything local...
-    if proxy_settings:
-        set_no_proxy_settings(proxy_settings)
+    The third tier is whatever ``urllib.request.getproxies()`` exposes for that
+    scheme (standard ``*_proxy`` environment variables).
 
+    ``no_proxy`` is resolved in ``set_no_proxy_settings`` using::
+
+        ``DD_PROXY_NO_PROXY`` > ``proxy.no_proxy`` (yaml) > ``NO_PROXY`` / ``no_proxy`` env.
+    """
+    cfg = config.get('proxy', {}) or {}
+    gp = getproxies()
+
+    http = _resolve_proxy_scheme('DD_PROXY_HTTP', cfg.get('http'), gp, 'http')
+    https = _resolve_proxy_scheme('DD_PROXY_HTTPS', cfg.get('https'), gp, 'https')
+
+    proxy_settings = {}
+    if http:
+        proxy_settings['http'] = http
+    if https:
+        proxy_settings['https'] = https
+
+    # Preserve odd ``*_proxy`` keys from the OS only when yaml/DD did not set http/https.
+    if not proxy_settings.get('http') and not proxy_settings.get('https') and gp:
+        proxy_settings = dict(gp)
+
+    set_no_proxy_settings(proxy_settings, cfg)
     return proxy_settings
 
 
@@ -123,7 +283,7 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     it will disable the proxy if the uri provided is to be reached directly.
 
     Keyword Arguments:
-        proxies -- dict with existing proxies: 'https', 'http', 'no' as pontential keys
+        proxies -- dict with existing proxies: 'https', 'http', 'no_proxy' (or legacy 'no')
         uri -- uri to determine if proxy is necessary or not.
         skip_proxy -- if True, the proxy dictionary returned will disable all proxies
     """
@@ -134,8 +294,13 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     if skip_proxy:
         proxies['http'] = None
         proxies['https'] = None
-    elif proxies.get('no'):
-        for url in proxies['no'].replace(';', ',').split(","):
+    elif proxies.get('no_proxy') or proxies.get('no'):
+        skip_src = proxies.get('no_proxy') or proxies.get('no') or ''
+        if isinstance(skip_src, (list, tuple)):
+            skip_parts = [str(x).strip() for x in skip_src if str(x).strip()]
+        else:
+            skip_parts = [p.strip() for p in str(skip_src).replace(';', ',').split(',') if p.strip()]
+        for url in skip_parts:
             if url in parsed_uri.netloc:
                 proxies['http'] = None
                 proxies['https'] = None

--- a/utils/tests/test_http.py
+++ b/utils/tests/test_http.py
@@ -46,6 +46,40 @@ def test_request_calls_session(monkeypatch):
         assert resp is mock_response
 
 
+def test_no_proxy_uri_list_falls_back_to_urllib_no_key():
+    from utils.http import _no_proxy_uri_list
+
+    assert _no_proxy_uri_list({"no": "a,b", "http": "x"}) == ["a", "b"]
+    assert _no_proxy_uri_list({"no_proxy": "c", "no": "d"}) == ["c"]
+
+
+def test_request_clears_scheme_proxies_when_no_proxy_bypass_matches(monkeypatch):
+    """
+    requests uses select_proxy(), which ignores no_proxy when http/https are set.
+    Null out scheme keys when should_bypass_proxy (integrations-core #5081) matches.
+    """
+    monkeypatch.setattr("config.config.get", lambda key, default=None: False)
+    fake_proxies = {
+        "http": "http://dummy:8888",
+        "https": "http://dummy:8888",
+        "no_proxy": "127.0.0.1,localhost,169.254.169.254,.datadoghq.com",
+    }
+    monkeypatch.setattr("utils.http.get_proxy", lambda: fake_proxies)
+
+    wrapper = RequestsWrapper()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    url = "https://unix.agent.datadoghq.com/intake/"
+    with patch.object(wrapper._session, "request", return_value=mock_response) as mock_request:
+        wrapper.request("POST", url, data=b"{}")
+        kwargs = mock_request.call_args[1]
+        p = kwargs["proxies"]
+        assert p["http"] is None
+        assert p["https"] is None
+        assert ".datadoghq.com" in (p.get("no_proxy") or "")
+
+
 @pytest.mark.parametrize(
     "skip_flag, expected_verify, warn_called",
     [

--- a/utils/tests/test_network.py
+++ b/utils/tests/test_network.py
@@ -3,7 +3,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
-import mock
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 import os
 from urllib.parse import urlparse
@@ -14,6 +17,9 @@ from utils.network import (
     get_proxy,
     get_site_url,
     LOCAL_PROXY_SKIP,
+    should_bypass_proxy,
+    _no_proxy_yaml_tokens,
+    _split_no_proxy_env_string,
 )
 
 
@@ -68,7 +74,11 @@ def test_get_proxy():
 
     with mock.patch('utils.network.getproxies', return_value={}):
         proxy_settings = get_proxy()
-        assert proxy_settings == {}
+        assert 'http' not in proxy_settings
+        assert 'https' not in proxy_settings
+        assert 'no_proxy' in proxy_settings
+        for host in LOCAL_PROXY_SKIP:
+            assert host in proxy_settings['no_proxy'].split(',')
 
     # remove all config options
     del config['proxy']
@@ -76,7 +86,11 @@ def test_get_proxy():
 
     with mock.patch('utils.network.getproxies', return_value={}):
         proxy_settings = get_proxy()
-        assert proxy_settings == {}
+        assert 'http' not in proxy_settings
+        assert 'https' not in proxy_settings
+        assert 'no_proxy' in proxy_settings
+        for host in LOCAL_PROXY_SKIP:
+            assert host in proxy_settings['no_proxy'].split(',')
 
     # restore defaults
     config.defaults['proxy'] = {
@@ -95,6 +109,7 @@ def test_get_proxy():
     assert 'https' in proxy_settings
     assert proxy_settings['https'] == 'http://bar'
     assert 'no_proxy' in proxy_settings
+    assert 'no' not in proxy_settings
 
     no_proxy = proxy_settings['no_proxy'].split(',')
     for host in LOCAL_PROXY_SKIP:
@@ -117,10 +132,149 @@ def test_get_proxy_from_env():
     assert 'https' in proxy_settings
     assert proxy_settings['https'] == 'http://bar'
     assert 'no_proxy' in proxy_settings
+    assert 'no' not in proxy_settings
 
     no_proxy = proxy_settings['no_proxy'].split(',')
-    for host in LOCAL_PROXY_SKIP + [proxy_skip_address]:
+    assert proxy_skip_address in no_proxy
+    for host in LOCAL_PROXY_SKIP:
         assert host in no_proxy
+
+    os.environ.pop('http_proxy', None)
+    os.environ.pop('https_proxy', None)
+    os.environ.pop('no_proxy', None)
+
+
+def test_https_proxy_precedence_dd_proxy_yaml_env():
+    """DD_PROXY_HTTPS > proxy.https (yaml) > HTTPS_PROXY / getproxies()."""
+    from config import config
+
+    os.environ.pop('DD_PROXY_HTTPS', None)
+    os.environ['HTTPS_PROXY'] = 'https://from-env-https'
+    config.data['proxy'] = {'https': 'https://from-yaml'}
+
+    p = get_proxy()
+    assert p.get('https') == 'https://from-yaml'
+
+    os.environ['DD_PROXY_HTTPS'] = 'https://from-dd'
+    p = get_proxy()
+    assert p.get('https') == 'https://from-dd'
+
+    os.environ.pop('DD_PROXY_HTTPS')
+    config.data.pop('proxy', None)
+    p = get_proxy()
+    assert p.get('https') == 'https://from-env-https'
+
+    os.environ.pop('HTTPS_PROXY')
+
+
+def test_no_proxy_yaml_overrides_no_proxy_env():
+    """``proxy.no_proxy`` (yaml) wins over ``NO_PROXY`` / ``no_proxy`` when DD is unset."""
+    from config import config
+
+    config.data.pop('proxy', None)
+    os.environ['no_proxy'] = 'from-env-only'
+    os.environ.pop('NO_PROXY', None)
+    os.environ.pop('DD_PROXY_NO_PROXY', None)
+
+    config['proxy'] = {
+        'http': 'http://dummy:8888',
+        'https': 'http://dummy:8888',
+        'no_proxy': ['.datadoghq.com', 'from-yaml-token'],
+    }
+    proxy_settings = get_proxy()
+    assert 'datadoghq.com' in proxy_settings['no_proxy'] or '.datadoghq.com' in proxy_settings['no_proxy']
+    assert 'from-yaml-token' in proxy_settings['no_proxy']
+    assert 'from-env-only' not in proxy_settings['no_proxy']
+    os.environ.pop('no_proxy', None)
+    config.data.pop('proxy', None)
+
+
+def test_dd_proxy_no_proxy_overrides_yaml_and_env():
+    from config import config
+
+    config.data.pop('proxy', None)
+    os.environ['no_proxy'] = 'from-env-only'
+    os.environ['DD_PROXY_NO_PROXY'] = 'from-dd-only'
+    config['proxy'] = {
+        'http': 'http://dummy:8888',
+        'https': 'http://dummy:8888',
+        'no_proxy': ['.datadoghq.com'],
+    }
+    proxy_settings = get_proxy()
+    assert proxy_settings['no_proxy'].split(',')[0] == 'from-dd-only'
+    assert 'datadoghq' not in proxy_settings['no_proxy']
+    assert 'from-env-only' not in proxy_settings['no_proxy']
+    os.environ.pop('no_proxy', None)
+    os.environ.pop('DD_PROXY_NO_PROXY', None)
+    config.data.pop('proxy', None)
+
+
+def test_no_proxy_star_yaml_skips_local_proxy_skip():
+    from config import config
+
+    # Do not use config.reset('proxy'): prior tests may have removed the key.
+    config.data.pop('proxy', None)
+    for k in ('no_proxy', 'NO_PROXY', 'http_proxy', 'https_proxy'):
+        os.environ.pop(k, None)
+
+    config['proxy'] = {
+        'http': 'http://dummy:8888',
+        'https': 'http://dummy:8888',
+        'no_proxy': ['*'],
+    }
+    proxy_settings = get_proxy()
+    assert proxy_settings['no_proxy'] == '*'
+    assert 'no' not in proxy_settings
+    for host in LOCAL_PROXY_SKIP:
+        assert host not in proxy_settings['no_proxy']
+
+
+def test_should_bypass_proxy_leading_dot_subdomains_only():
+    rules = ['.y.com']
+    assert should_bypass_proxy('https://x.y.com/path', rules)
+    assert not should_bypass_proxy('https://y.com/', rules)
+
+
+def test_should_bypass_proxy_domain_matches_self_and_subdomains():
+    rules = ['example.com']
+    assert should_bypass_proxy('https://www.example.com/x', rules)
+    assert should_bypass_proxy('https://example.com/', rules)
+    assert not should_bypass_proxy('https://notexample.com/', rules)
+    assert not should_bypass_proxy('https://example.org/', rules)
+
+
+def test_should_bypass_proxy_wildcard_subdomain_prefix():
+    rules = ['*.example.com']
+    assert should_bypass_proxy('https://www.example.com/', rules)
+    assert not should_bypass_proxy('https://example.com/', rules)
+
+
+def test_should_bypass_proxy_star():
+    assert should_bypass_proxy('https://any.host/', ['127.0.0.1', '*'])
+
+
+def test_should_bypass_proxy_unix_scheme():
+    assert should_bypass_proxy('unix:///var/run/docker.sock', ['127.0.0.1'])
+
+
+def test_should_bypass_proxy_ip_cidr():
+    rules = ['127.1.0.0/25']
+    assert should_bypass_proxy('http://127.1.0.50/', rules)
+    assert should_bypass_proxy('http://127.1.0.100/', rules)
+    assert not should_bypass_proxy('http://127.1.0.150/', rules)
+
+
+def test_should_bypass_proxy_empty_rules():
+    assert not should_bypass_proxy('https://example.com/', [])
+
+
+def test_no_proxy_yaml_string_not_split_on_commas():
+    assert _no_proxy_yaml_tokens('a,b,c') == ['a,b,c']
+
+
+def test_split_no_proxy_env_string():
+    assert _split_no_proxy_env_string('a, b; c') == ['a', 'b', 'c']
+
 
 def test_get_site():
     from config import config


### PR DESCRIPTION
## Problem

Outbound HTTP used `requests` with a `proxies` dict that included both scheme URLs (`http` / `https`) and `no_proxy`. `urllib`’s `select_proxy()` (used by Requests) **does not consult `no_proxy` when `http` or `https` keys are set**, so hosts that should bypass the corporate proxy (e.g. `api.datadoghq.com` listed in `NO_PROXY`) could still be sent through the proxy. That matches the class of issues fixed in integrations-core (`should_bypass_proxy`, #5081).

Separately, proxy URL and `no_proxy` resolution did not follow the same precedence as the main Datadog Agent (`DD_PROXY_*` vs `datadog.yaml` vs environment).

## What this PR does

- **Bypass:** Before each request, if `should_bypass_proxy(url, no_proxy_uris)` matches, clear `http` and `https` entries in the merged `proxies` dict so the connection goes direct while preserving `no_proxy` metadata for logging.
- **Precedence:** Align HTTP/HTTPS proxy URLs and `no_proxy` with the Agent stack: `DD_PROXY_HTTP` / `DD_PROXY_HTTPS` / `DD_PROXY_NO_PROXY` > `proxy.*` in `datadog.yaml` > standard `*_proxy` / `NO_PROXY` env (via `getproxies()` where applicable). `LOCAL_PROXY_SKIP` behavior is preserved.
- **Docs & tests:** `datadog.yaml.example` notes and expanded unit tests in `test_network.py` / `test_http.py`.

## Motivation

- AGENT-16069


## Notes

Invalid or leftover `https_proxy` values in the environment can still break connectivity; this change ensures that when `NO_PROXY` / `proxy.no_proxy` applies to a host, the agent does not keep forcing traffic through a proxy for that URL.


Made with [Cursor](https://cursor.com)