### PR TITLE
Default disable_console_logging to True

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -26,7 +26,7 @@ DEFAULT_DOGSTATSD_PORT = 8125
 DEFAULT_BIND_HOST = 'localhost'
 DEFAULT_LOGGING_CONFIG = {
     'disable_file_logging': False,
-    'disable_console_logging': False,
+    'disable_console_logging': True,
     'agent_log_file': os.path.join(DEFAULT_LOG_PATH, 'agent.log'),
     'dogstatsd_log_file': os.path.join(DEFAULT_LOG_PATH, 'dogstatsd.log'),
 }


### PR DESCRIPTION
## What does this PR do?

Defaults `disable_console_logging` to `True` in `config/default.py`.

## Motivation

On AIX, the agent runs as an SRC subsystem where console output has no useful destination. The option to suppress it already exists (added in 57e34e9) but defaults to `False`, requiring every AIX deployment to manually opt out. This has surfaced in multiple support tickets (Ticket #801870, Ticket #1326582, Ticket #1377502) — Ticket #1326582 is explicitly cited in the internal AIX Agent Troubleshooting doc under *"How do I stop sending the Agent logs to the console?"*

Customers who want console output can still opt in via `disable_console_logging: false` in `datadog.yaml`.

**Note:** The last published release is 1.1.6 (June 2022). The `disable_console_logging` option has never been included in a release — no customer is currently running code that includes it, so there is no backwards compatibility concern.

## Describe how you validated your changes

- Verified agent starts and writes to `agent.log` as normal on AIX 7.2
- Verified no output appears on the system console when running as an SRC subsystem
- Verified `disable_console_logging: false` in `datadog.yaml` restores console output