### PR TITLE
Fix AIX package scripts: use || true for best-effort SRC/inittab cleanup

### DIFF
--- a/omnibus/package-scripts/agent/aix/postrm
+++ b/omnibus/package-scripts/agent/aix/postrm
@@ -20,19 +20,13 @@ DATADOG_GROUP=dd-agent
 
 stop_datadog_services()
 {
-  # Stop an already running agent
-  set +e
-  stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
-  set -e
+    stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
 }
 
 purge_datadog_services()
 {
-  set -e
-  # adding inittab entry
-  rmitab ${SERVICE_NAME}
-
-  rmssys -s ${SERVICE_NAME} > /dev/null 2>&1
+    rmitab ${SERVICE_NAME} > /dev/null 2>&1 || true
+    rmssys -s ${SERVICE_NAME} > /dev/null 2>&1 || true
 }
 
 purge_datadog_files()

--- a/omnibus/package-scripts/agent/aix/preinst
+++ b/omnibus/package-scripts/agent/aix/preinst
@@ -20,11 +20,9 @@ set -e
 
 tentative_stop_datadog_services()
 {
-  # Stop an already running agent if it exists
-  set +e
-  stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
-  sleep 6
-  set -e
+    # Stop an already running agent if it exists
+    stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
+    sleep 6
 }
 
 tentative_stop_datadog_services

--- a/omnibus/package-scripts/agent/aix/unconfig
+++ b/omnibus/package-scripts/agent/aix/unconfig
@@ -37,9 +37,9 @@ stop_datadog_services
 remove_system_services
 
 # Remove symlink to agent CLI
-set +e
-test -L /usr/bin/datadog-agent && rm -f /usr/bin/datadog-agent
-set -e
+if [ -L /usr/bin/datadog-agent ]; then
+    rm -f /usr/bin/datadog-agent
+fi
 
 # Remove installation and config directories not always cleaned by installp
 rm -rf ${INSTALL_DIR}

--- a/omnibus/package-scripts/agent/aix/unconfig
+++ b/omnibus/package-scripts/agent/aix/unconfig
@@ -5,13 +5,12 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-# This script is RPM-specific
-# It is run at the very end of an install/upgrade of the package
-# It is NOT run on removal of the package
+# Run by installp during deinstallation (datadog-unix-agent.unconfig member in liblpp.a).
+# Stops the agent, removes SRC subsystem, and cleans up installation directories.
 #
 # .deb: n/a
-# .rpm: STEP 6 of 6
-# .bff: STEP ? of ? (TODO)
+# .rpm: STEP 6 of 6 (config script, not called on removal)
+# .bff: called by installp -u before file removal
 
 INSTALL_DIR=/opt/datadog-agent
 CONFIG_DIR=/etc/datadog-agent
@@ -24,28 +23,27 @@ set -e
 
 stop_datadog_services()
 {
-  # Stop an already running agent
-  set +e
-  stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
-  set -e
+    stopsrc -s ${SERVICE_NAME} > /dev/null 2>&1 || true
 }
 
 remove_system_services()
 {
-    # best effort
-    set +e
-    rmitab ${SERVICE_NAME} > /dev/null
-    rmssys -s ${SERVICE_NAME} > /dev/null
-    set -e
+    # best effort — use || true so individual failures don't abort the script
+    rmitab ${SERVICE_NAME} > /dev/null 2>&1 || true
+    rmssys -s ${SERVICE_NAME} > /dev/null 2>&1 || true
 }
 
 stop_datadog_services
 remove_system_services
 
-# remove symbolc link to the agent
-if [ -L /usr/bin/datadog-agent]; then
-    rm -f /usr/bin/datadog-agent
-fi
+# Remove symlink to agent CLI
+set +e
+test -L /usr/bin/datadog-agent && rm -f /usr/bin/datadog-agent
+set -e
 
+# Remove installation and config directories not always cleaned by installp
+rm -rf ${INSTALL_DIR}
+rm -rf ${CONFIG_DIR}
+rm -rf ${LOG_DIR}
 
 exit 0


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where uninstalling the agent leaves a `datadog-agent` entry registered in the AIX SRC subsystem (`lssrc -a` shows it as `inoperative`). Manual `rmssys -s datadog-agent` was required to clean up.

Replaces the `set +e`/`set -e` pattern with `|| true` on all best-effort cleanup commands in `unconfig`, `preinst`, and `postrm`.

## Motivation

`rmitab` fails when there is no inittab entry (normal for installs that don't use inittab). Due to AIX `/bin/sh` (ksh88) `set` modifying global shell state inside functions, the script exits before `rmssys` runs — leaving the SRC subsystem registered after deinstall.

## Describe how you validated your changes

Tested on AIX 7.2 TL4:
- **Before fix:** deinstall left `datadog-agent inoperative` in `lssrc -a`
- **After fix:** `lssrc -a | grep datadog` returns nothing after deinstall